### PR TITLE
moved init to the thi directory

### DIFF
--- a/cmd/mkroot/commands.go
+++ b/cmd/mkroot/commands.go
@@ -209,14 +209,14 @@ func (m *mkfs) Execute() error {
 			}
 		}()
 
-		if err := copyFile(initPath, filepath.Join(initDir, "init")); err != nil {
-			return fmt.Errorf("failed to copy init: %v", err)
-		}
-
 		configDir := filepath.Join(initDir, "thi")
 
 		if err := os.MkdirAll(configDir, 0755); err != nil {
 			return fmt.Errorf("failed to create config dir in init drive: %v", err)
+		}
+
+		if err := copyFile(initPath, filepath.Join(configDir, "init")); err != nil {
+			return fmt.Errorf("failed to copy init: %v", err)
 		}
 
 		if err := os.WriteFile(filepath.Join(configDir, "run.json"), runJson, 0755); err != nil {


### PR DESCRIPTION
## Description

I fixed moved the init to the `thi` directory in the init drive. This is necessary because during the boot process the contents of the thi drive is deleted to save space. I moved the init binary to make this process simple