### PR TITLE
fix: disabled cgo to produce static binary

### DIFF
--- a/cmd/mkroot/commands.go
+++ b/cmd/mkroot/commands.go
@@ -147,6 +147,8 @@ func useLocalInit(repo string) (initPath string, runConfig []byte, err error) {
 	defer goBack()
 
 	install := exec.Command(goPath, "build", ".")
+	install.Env = append(os.Environ(), "CGO_ENABLED=0")
+
 	if err := install.Run(); err != nil {
 		return "", nil, fmt.Errorf("failed to build thi-startup init: %v", err)
 	}


### PR DESCRIPTION
Disabled CGO to solve problem where init panics when booting